### PR TITLE
Removed extraneous information

### DIFF
--- a/transcription/TEI/hu-hm2177-fb046r.xml
+++ b/transcription/TEI/hu-hm2177-fb046r.xml
@@ -9,44 +9,23 @@
     </zone>
     <zone type ="main">
         <line>With what truth I may say</line>
-        <line>Roma Roma Roma</line>
+        <line><tagUsage gi="foreign" render="#it">Roma Roma Roma</tagUsage></line>
         <line><tagUsage gi="foreign" render="#it">Non e puis come era prima</tagUsage></line>
-        <line>My lost William,<del rend = “strikethrough”><unclear></del>thou in whom</line>
-        <line>Some <superscript>bright</superscript><del rend = “strikethrough”>sweet</del>spirit lived and did</line>
+        <line>My lost William,<del rend = "strikethrough"><unclear></del>thou in whom</line>
+        <line>Some <add place="superlinear">bright</add><del rend = "strikethrough">sweet</del>spirit lived and did</line>
         <line>That decaying robe consume</l>
-        <line>Which its<del rend = "strikethrough"><unclear></del><superscript><unclear>faintly</superscript> faintly hid</line>
+        <line>Which its<del rend = "strikethrough"><unclear></del><add place="superlinear"><unclear>faintly</add> faintly hid</line>
         <line><del rend = "strikethrough">be the thy remains</del></line>
         <line>Here its as<unclear>find a tomb</line>
-        <line><del rend = "strikethrough">Under</del> <superscript>But be</superscript>neath this pyramid</line>
+        <line><del rend = "strikethrough">Under</del> <add place="superlinear">But be</add>neath this pyramid</line>
         <line><del rend = "strikethrough">Lay thy bones if - thou canst die</del></line>
         <line><del rend = "strikethrough">Rest thy bones - then is a shrine</del></line>
-        <line>Where art thou <del rend = “strikethrough”>you</del> my gentle <del rend = "strikethrough">boy</del><superscript>child</superscript></line>
+        <line>Where art thou <del rend = "strikethrough">you</del> my gentle <del rend = "strikethrough">boy</del><add place="superlinear">child</add></line>
         <line><del rend = "strikethrough">Die fied<unclear>in the to the</del> living weeds</line>
         <line>Let me <del rend = "strikethrough">Whose child I</del>think thy spirit feels</line>
         <line>Within its <del rend = "strikethrough"><unclear></del> life intense and mild</line>
         <line>The <del rend = "strikethrough">g<unclear reason="illegible" extent="3" unit="chars"></unclear> living </del> love of living <del rend = "strikethrough">flower</del> <handShift new ="pbs"> saves </handShift></line>
         <line>among these tombs of ruins wild</line>
         <line><del rend = "strikethrough">could I believe that</del></line>
-        </zone>
-        </surface>
-        
-        <surface>
-            <zone type = "main">
-        <line>Originality does not consist</line>
-        <line><unclear reason="illegible" extent="2" unit="chars"></unclear> words <unclear reason="illegible" extent="4" unit="chars"></unclear> or str<unclear reason="illegible" extent="2" unit="chars"></unclear></line>
-        <line>or combinations of mind &amp; </line>
-        <line>language different from <unclear reason="illegible" extent="2" unit="chars"></unclear></line>
-        <line>Which have gone before <unclear reason="illegible" extent="2" unit="chars"></unclear>it </line>
-        <line>does not consist only if <unclear reason="illegible" extent="1" unit="chars"></unclear></line>
-        <line>a<unclear reason="illegible" extent="1"unit="chars"</line>
-            </zone>
-            <zone type ="upside down">
-                <handShift new = "pbs" />
-        <line> A melancholy gladness </line>
-        <line> Let me think that this</line>
-        <line>Of the <del rend = "strikethrough"> living breathing</del rend = "strikethrough"></line>
-        <line>An unknown honor may</line>
-        <line>With these hues and <unclear reason="illegible" extent="1"unit="chars" may help</line>
-        <line>A portion</line>
         </zone>
         </surface>


### PR DESCRIPTION
Note: Most tags were not closed, so TEI was not functional in document and failed to run

Removed:

```
    <surface>
        <zone type = "main">
    <line>Originality does not consist</line>
    <line><unclear reason="illegible" extent="2" unit="chars"></unclear> words <unclear reason="illegible" extent="4" unit="chars"></unclear> or str<unclear reason="illegible" extent="2" unit="chars"></unclear></line>
    <line>or combinations of mind &amp; </line>
    <line>language different from <unclear reason="illegible" extent="2" unit="chars"></unclear></line>
    <line>Which have gone before <unclear reason="illegible" extent="2" unit="chars"></unclear>it </line>
    <line>does not consist only in <unclear reason="illegible" extent="1" unit="chars"></line>
    <line>a<unclear reason="illegible" extent="1"unit="chars"</line>
        </zone>
        <zone type ="upside down">
            <handShift new = "pbs" />
    <line> A melancholy gladness </line>
    <line> Let me think that this</line>
    <line>Of the <del rend = "strikethrough"> living breathing</del rend = "strikethrough"></line>
    <line>An unknown honor may</line>
    <line>With these hues and <unclear reason="illegible" extent="1"unit="chars" may help</line>
    <line>A portion</line>
    </zone>
    </surface>
```
